### PR TITLE
Add snippet types to singular filetypes for access 

### DIFF
--- a/coq+snippets+v2.json
+++ b/coq+snippets+v2.json
@@ -56,16 +56,21 @@
       "c": true
     },
     "dart": {
-      "dart-flutter": true
+      "dart-flutter": true,
+      "flutter": true
     },
     "dart-flutter": {},
     "debug": {},
     "diff": {},
-    "django": {},
+    "django": {
+      "djangohtml": true
+    },
     "djangohtml": {},
     "dockerfile": {},
     "dosini": {},
-    "dotenv": {},
+    "dotenv": {
+      "dotenv-safe": true
+    },
     "dotenv-safe": {},
     "eelixir": {
       "html": true

--- a/coq+snippets+v2.json
+++ b/coq+snippets+v2.json
@@ -55,7 +55,9 @@
     "d": {
       "c": true
     },
-    "dart": {},
+    "dart": {
+      "dart-flutter": true
+    },
     "dart-flutter": {},
     "debug": {},
     "diff": {},
@@ -304,7 +306,13 @@
     "vue": {
       "css": true,
       "html": true,
-      "javascript": true
+      "javascript": true,
+      "vue-pug": true,
+      "vue-script": true,
+      "vue-script-router": true,
+      "vue-script-vuex": true,
+      "vue-template": true,
+      "vuex": true
     },
     "vue-pug": {},
     "vue-script": {},


### PR DESCRIPTION
Based on (#24), Added support for other snippets within certain filetypes like below:

```json
"dart": {
  "dart-flutter": true,
  "flutter": true
},
```

Now, they can be accessed.